### PR TITLE
Avoid passing Maven parameters to core library when oldApi parameter …

### DIFF
--- a/src/main/java/io/redskap/swagger/brake/maven/OptionsFactory.java
+++ b/src/main/java/io/redskap/swagger/brake/maven/OptionsFactory.java
@@ -9,24 +9,29 @@ import java.util.Collections;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class OptionsFactory {
     public static Options create(RunnerParameter parameter) {
         Options options = new Options();
-        options.setOldApiPath(parameter.getOldApi());
-        options.setMavenRepoUrl(parameter.getMavenRepoUrl());
-        options.setMavenSnapshotRepoUrl(parameter.getMavenSnapshotRepoUrl());
-        options.setMavenRepoUsername(parameter.getMavenRepoUsername());
-        options.setMavenRepoPassword(parameter.getMavenRepoPassword());
-        options.setGroupId(parameter.getGroupId());
-        options.setArtifactId(parameter.getArtifactId());
-        options.setCurrentArtifactVersion(parameter.getCurrentVersion());
+        if (isBlank(parameter.getOldApi())) {
+            options.setMavenRepoUrl(parameter.getMavenRepoUrl());
+            options.setMavenSnapshotRepoUrl(parameter.getMavenSnapshotRepoUrl());
+            options.setMavenRepoUsername(parameter.getMavenRepoUsername());
+            options.setMavenRepoPassword(parameter.getMavenRepoPassword());
+            options.setGroupId(parameter.getGroupId());
+            options.setArtifactId(parameter.getArtifactId());
+            options.setCurrentArtifactVersion(parameter.getCurrentVersion());
+            options.setApiFilename(parameter.getApiFilename());
+        } else {
+            options.setOldApiPath(parameter.getOldApi());
+        }
+
         options.setNewApiPath(parameter.getNewApi());
         options.setOutputFilePath(parameter.getOutputFilePath());
         options.setOutputFormats(resolveOutputFormats(parameter));
         options.setDeprecatedApiDeletionAllowed(parameter.getDeprecatedApiDeletionAllowed());
         options.setBetaApiExtensionName(parameter.getBetaApiExtensionName());
-        options.setApiFilename(parameter.getApiFilename());
         return options;
     }
 

--- a/src/test/java/io/redskap/swagger/brake/maven/OptionsFactoryTest.java
+++ b/src/test/java/io/redskap/swagger/brake/maven/OptionsFactoryTest.java
@@ -69,4 +69,28 @@ public class OptionsFactoryTest {
         assertThat(result.getOutputFilePath()).isEqualTo(parameter.getOutputFilePath());
         assertThat(result.getOutputFormats()).isEqualTo(ImmutableSet.of(OutputFormat.HTML));
     }
+
+    @Test
+    public void testWhenOldApiIsProvidedDefaultMavenValuesAreIgnored() {
+        // given
+        RunnerParameter parameter = RunnerParameter.builder()
+          .newApi("newApi")
+          .oldApi("oldApi")
+          .groupId("groupId")
+          .artifactId("artifactId")
+          .currentVersion("currentVersion")
+          .outputFilePath("outputFilePath")
+          .outputFormats(ImmutableList.of("html"))
+          .build();
+        // when
+        Options result = OptionsFactory.create(parameter);
+        // then
+        assertThat(result.getNewApiPath()).isEqualTo(parameter.getNewApi());
+        assertThat(result.getOldApiPath()).isEqualTo(parameter.getOldApi());
+        assertThat(result.getOutputFilePath()).isEqualTo(parameter.getOutputFilePath());
+        assertThat(result.getOutputFormats()).isEqualTo(ImmutableSet.of(OutputFormat.HTML));
+        assertThat(result.getGroupId()).isNull();
+        assertThat(result.getArtifactId()).isNull();
+        assertThat(result.getCurrentArtifactVersion()).isNull();
+    }
 }


### PR DESCRIPTION
…is explicitly set