### PR TITLE
Restrict Renovate PR updates to scheduled window

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   ],
   "minimumReleaseAge": "30 days",
   "schedule": ["on monday"],
+  "updateNotScheduled": false,
   "vulnerabilityAlerts": {
     "minimumReleaseAge": "0 days",
     "enabled": true,


### PR DESCRIPTION
## Summary

- Adds \`updateNotScheduled: false\` next to the existing \`schedule\` setting

## Why

\`schedule\` only gates *new* PR creation by default. Without this flag, Renovate freely rebases and updates already-open PRs at any time during the week. Setting \`updateNotScheduled: false\` makes the Monday schedule apply to both PR creation and PR updates, so Renovate is fully quiet outside that window.